### PR TITLE
Decode entities before sharing

### DIFF
--- a/includes/admin/services/class-rop-facebook-service.php
+++ b/includes/admin/services/class-rop-facebook-service.php
@@ -450,7 +450,7 @@ class Rop_Facebook_Service extends Rop_Services_Abstract {
 		$new_post['message'] = $post_details['content'];
 
 		if ( ! empty( $post_details['post_url'] ) ) {
-			$new_post['name'] = get_the_title( $post_details['post_id'] );
+			$new_post['name'] = html_entity_decode( get_the_title( $post_details['post_id'] ) );
 			$new_post['link'] = $this->get_url( $post_details );
 		}
 
@@ -464,7 +464,7 @@ class Rop_Facebook_Service extends Rop_Services_Abstract {
 			$this->logger->alert_success(
 				sprintf(
 					'Successfully shared %s to %s on %s ',
-					get_the_title( $post_details['post_id'] ),
+					html_entity_decode( get_the_title( $post_details['post_id'] ) ),
 					$args['user'],
 					$post_details['service']
 				)

--- a/includes/admin/services/class-rop-linkedin-service.php
+++ b/includes/admin/services/class-rop-linkedin-service.php
@@ -392,7 +392,7 @@ class Rop_Linkedin_Service extends Rop_Services_Abstract {
 
 		$new_post['comment']                  = $post_details['content'];
 		$new_post['content']['description']   = $post_details['content'];
-		$new_post['content']['title']         = get_the_title( $post_details['post_id'] );
+		$new_post['content']['title']         = html_entity_decode( get_the_title( $post_details['post_id'] ) );
 		$new_post['content']['submitted-url'] = $this->get_url( $post_details );
 
 		$new_post['visibility']['code'] = 'anyone';
@@ -407,7 +407,7 @@ class Rop_Linkedin_Service extends Rop_Services_Abstract {
 			$this->logger->alert_success(
 				sprintf(
 					'Successfully shared %s to %s on %s ',
-					get_the_title( $post_details['post_id'] ),
+					html_entity_decode( get_the_title( $post_details['post_id'] ) ),
 					$args['user'],
 					$post_details['service']
 				)

--- a/includes/admin/services/class-rop-tumblr-service.php
+++ b/includes/admin/services/class-rop-tumblr-service.php
@@ -395,7 +395,7 @@ class Rop_Tumblr_Service extends Rop_Services_Abstract {
 			$this->logger->alert_success(
 				sprintf(
 					'Successfully shared %s to %s on %s ',
-					get_the_title( $post_details['post_id'] ),
+					html_entity_decode( get_the_title( $post_details['post_id'] ) ),
 					$args['user'],
 					$post_details['service']
 				)

--- a/includes/admin/services/class-rop-twitter-service.php
+++ b/includes/admin/services/class-rop-twitter-service.php
@@ -347,7 +347,7 @@ class Rop_Twitter_Service extends Rop_Services_Abstract {
 			$this->logger->alert_success(
 				sprintf(
 					'Successfully shared %s to %s on %s ',
-					get_the_title( $post_details['post_id'] ),
+					html_entity_decode( get_the_title( $post_details['post_id'] ) ),
 					$args['user'],
 					$post_details['service']
 				)


### PR DESCRIPTION
There are instances on Facebook where special chars in the title get's converted to their entities and Facebook, Tumblr doesn't change them back.

![screen_1](https://user-images.githubusercontent.com/10324144/40332997-45cd50a4-5d24-11e8-943a-38743df3870b.jpg)


This pull fixes that and also the log entries were having the entity chars as well, so i added the function there as well for all services.