### PR TITLE
global settings default for custom_share_messages_order had wrong name

### DIFF
--- a/includes/admin/class-rop-global-settings.php
+++ b/includes/admin/class-rop-global-settings.php
@@ -155,7 +155,7 @@ class Rop_Global_Settings {
 		'beta_user'             => false,
 		'remote_check'          => false,
 		'custom_messages'       => false,
-		'custom_share_order'    => false,
+		'custom_messages_share_order'    => false,
 		'instant_share'         => true,
 		'true_instant_share'    => true,
 		'instant_share_default' => false,

--- a/includes/admin/helpers/class-rop-post-format-helper.php
+++ b/includes/admin/helpers/class-rop-post-format-helper.php
@@ -162,14 +162,18 @@ class Rop_Post_Format_Helper {
 				return wp_parse_args( array( 'display_content' => $share_content ), $default_content );
 			}
 		}
+
+		$settings = new Rop_Settings_Model();
+		$general_settings = $settings->get_settings();
+
 		/**
 		 * Check custom messages(share variations) if exists.
 		 */
 		$custom_messages = get_post_meta( $post_id, 'rop_custom_messages_group', true );
 
-		if ( ! empty( $custom_messages ) ) {
+		// If share variations exist for this post and the option to use them is turned on
+		if ( ! empty( $custom_messages ) && ! empty( $general_settings['custom_messages'] ) ) {
 
-			$settings                    = new Rop_Settings_Model();
 			$custom_messages_share_order = $settings->get_custom_messages_share_order();
 
 			if ( $custom_messages_share_order ) {


### PR DESCRIPTION
Dont share custom messages (share variations) if option is not turned on. Close Codeinwp/tweet-old-post-pro#361