### PR TITLE
Fix `is.gd` url shorted response handling

### DIFF
--- a/includes/admin/abstract/class-rop-services-abstract.php
+++ b/includes/admin/abstract/class-rop-services-abstract.php
@@ -332,6 +332,8 @@ abstract class Rop_Services_Abstract {
 	/**
 	 * Method to generate url for service post share.
 	 *
+	 * Apply short url if available.
+	 *
 	 * @param array $post_details The post details to be published by the service.
 	 *
 	 * @return string
@@ -340,28 +342,17 @@ abstract class Rop_Services_Abstract {
 	 */
 	protected function get_url( $post_details ) {
 
-		$link = ( ! empty( $post_details['post_url'] ) ) ? ' ' . $post_details['post_url'] : '';
-
-		if ( empty( $link ) ) {
+		if ( empty( $post_details['post_url'] ) ) {
 			return '';
 		}
 
-		if ( ! $post_details['short_url'] ) {
-			return $link;
-		}
-		if ( empty( $post_details['short_url_service'] ) ) {
-			return $link;
+		if ( empty( $post_details['short_url'] ) || empty( $post_details['short_url_service'] || 'wp_short_url' === $post_details['short_url_service'] ) ) {
+			return ' ' . $post_details['post_url'];
 		}
 
 		$post_format_helper = new Rop_Post_Format_Helper();
 
-		if ( $post_details['short_url_service'] === 'wp_short_url' ) {
-			return $link;
-		}
-
-		$link = ' ' . $post_format_helper->get_short_url( $post_details['post_url'], $post_details['short_url_service'], $post_details['shortner_credentials'] );
-
-		return $link;
+		return ' ' . $post_format_helper->get_short_url( $post_details['post_url'], $post_details['short_url_service'], $post_details['shortner_credentials'] );
 	}
 
 	/**

--- a/includes/admin/shortners/class-rop-isgd-shortner.php
+++ b/includes/admin/shortners/class-rop-isgd-shortner.php
@@ -42,20 +42,20 @@ class Rop_Isgd_Shortner extends Rop_Url_Shortner_Abstract {
 		$response = $this->callAPI(
 			'https://is.gd/create.php',
 			array( 'method' => 'get' ),
-			array( 
+			array(
 				'format' => 'simple',
-				'url' => $url
+				'url' => $url,
 			),
 			null
 		);
-		
+
 		$shortURL = $url;
 		if ( intval( $response['error'] ) == 200 && wp_http_validate_url( $response['response'] ) ) {
 			$shortURL = $response['response'];
 		} else {
-			$this->error->throw_exception( 'Error', 'is.gd error: ' . print_r( $response, true) );
+			$this->error->throw_exception( 'Error', 'is.gd error: ' . print_r( $response, true ) );
 		}
-		
+
 		return $shortURL;
 	}
 }

--- a/includes/admin/shortners/class-rop-isgd-shortner.php
+++ b/includes/admin/shortners/class-rop-isgd-shortner.php
@@ -40,15 +40,22 @@ class Rop_Isgd_Shortner extends Rop_Url_Shortner_Abstract {
 	public function shorten_url( $url ) {
 
 		$response = $this->callAPI(
-			'https://is.gd/api.php',
+			'https://is.gd/create.php',
 			array( 'method' => 'get' ),
-			array( 'longurl' => $url),
+			array( 
+				'format' => 'simple',
+				'url' => $url
+			),
 			null
 		);
+		
 		$shortURL = $url;
-		if ( intval( $response['error'] ) == 200 ) {
+		if ( intval( $response['error'] ) == 200 && wp_http_validate_url( $response['response'] ) ) {
 			$shortURL = $response['response'];
+		} else {
+			$this->error->throw_exception( 'Error', 'is.gd error: ' . print_r( $response, true) );
 		}
+		
 		return $shortURL;
 	}
 }


### PR DESCRIPTION
Close https://github.com/Codeinwp/tweet-old-post-pro/issues/480

## Summary

Added better service response handling and upgraded the URL to use the latest API endpoint.

## Description

The posting mechanism added a message like that ends `Error, database insert failed`. This was caused by the function `get_url`, which tries to shorten the URL by using `is.gd` service.

To replicate this issue you need a valid domain. The services work only with URLs that are available on the internet and are not on the blocklist (FYI: tastewp URLs are on the blacklist).

The main problem is that when services cannot process the URL, it will give something like this as a response:

```
HTTP/1.1 200 OK
CF-Cache-Status: DYNAMIC
CF-RAY: 8498b6a71ad9c29b-VIE
Connection: keep-alive
Content-Encoding: gzip
Content-Type: text/html; charset=UTF-8
Date: Mon, 22 Jan 2024 15:08:39 GMT
Server: cloudflare
Set-Cookie: __cf_bm=mW5ZRykpgHu1OaXthztTO_deplxvZmh1GJQQh5ZjYe4-1705936119-1-Ac1gBGUi4m8U+2XoNRIPkBDKqlflPfMpNyDzVnOqUUboQiG9+WsZOp8/Iv56lF01CuOq1UdT0QkG9pzUkVA7fvQ=; path=/; expires=Mon, 22-Jan-24 15:38:39 GMT; domain=.is.gd; HttpOnly; Secure; SameSite=None
Transfer-Encoding: chunked

Error, database insert failed
```

Because the response error is `200`, the code accepted the string without further verification.

To solve this, I added a check to see that the response is a URL.

Any other response from the server will be treated as an error and logged:

![image](https://github.com/Codeinwp/tweet-old-post/assets/17597852/28268f3e-1243-404f-9805-f8c2ea0d1e11)

There was also a report about the same issue for people who did not use the URL shortener https://github.com/Codeinwp/tweet-old-post-pro/issues/480#issuecomment-1896311145

I tested all the codes and could not reproduce them.

## Testing

- Check if the logger is working when `is.gd` is not giving the URL. You can test with TasteWP or a local instance.
- Check if the URL is shortened. For `is.gd`, you will need a non-banned and online available instance. 

