### PR TITLE
[Publish Now] Use account active state as default value for toggle check

### DIFF
--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -799,7 +799,7 @@ class Rop_Admin {
 			$default['action']                   = 'yes' === get_post_meta( $post->ID, 'rop_publish_now', true );
 			$default['instant_share_by_default'] = $default['action'];
 		}
-		$default['active'] = get_post_meta( $post->ID, 'rop_publish_now_accounts', true );
+		$default['page_active_accounts'] = get_post_meta( $post->ID, 'rop_publish_now_accounts', true );
 
 		return $default;
 	}
@@ -810,10 +810,13 @@ class Rop_Admin {
 	 * @param int $post_id The post ID.
 	 */
 	public function maybe_publish_now( $post_id ) {
+
+		error_log( 'maybe_publish_now: ' . $post_id . '  ---- ' . print_r( $_POST, true ) );
+
 		if ( empty( $_POST['rop_publish_now_nonce'] ) ) {
 			return;
 		}
-		if ( ! wp_verify_nonce( $_POST['rop_publish_now_nonce'], 'rop_publish_now_nonce' ) ) {
+		if ( ! wp_verify_nonce( $_POST['rop_publish_now_nonce'], 'rop_publish_nownonce' ) ) {
 			return;
 		}
 

--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -807,14 +807,17 @@ class Rop_Admin {
 	/**
 	 * Publish now, if enabled.
 	 *
+	 * This is hooked to the `save_post` action.
+	 * The values from the Publish Now metabox are saved to the post meta.
+	 *
 	 * @param int $post_id The post ID.
 	 */
 	public function maybe_publish_now( $post_id ) {
-	
+
 		if ( empty( $_POST['rop_publish_now_nonce'] ) ) {
 			return;
 		}
-		if ( ! wp_verify_nonce( $_POST['rop_publish_now_nonce'], 'rop_publish_nownonce' ) ) {
+		if ( ! wp_verify_nonce( $_POST['rop_publish_now_nonce'], 'rop_publish_now_nonce' ) ) {
 			return;
 		}
 
@@ -852,19 +855,22 @@ class Rop_Admin {
 		// reject the extra.
 		$enabled = array_diff( $enabled, $extra );
 
-		$instant_share_custom_content = array();
+		/**
+		 * Save an account as active to instant share via its ID along with the custom message in the post meta.
+		 */
+		$publish_now_active_accounts_settings = array();
 
 		foreach ( $enabled as $account_id ) {
 			$custom_message = ! empty( $_POST[ $account_id ] ) ? $_POST[ $account_id ] : '';
-			$instant_share_custom_content[ $account_id ] = $custom_message;
+			$publish_now_active_accounts_settings[ $account_id ] = $custom_message;
 		}
 
 		update_post_meta( $post_id, 'rop_publish_now', 'yes' );
-		update_post_meta( $post_id, 'rop_publish_now_accounts', $instant_share_custom_content );
+		update_post_meta( $post_id, 'rop_publish_now_accounts', $publish_now_active_accounts_settings );
 
 		// If user wants to run this operation on page refresh instead of via Cron.
 		if ( $settings->get_true_instant_share() ) {
-			$this->rop_cron_job_publish_now( $post_id, $instant_share_custom_content );
+			$this->rop_cron_job_publish_now( $post_id, $publish_now_active_accounts_settings );
 			return;
 		}
 

--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -810,9 +810,7 @@ class Rop_Admin {
 	 * @param int $post_id The post ID.
 	 */
 	public function maybe_publish_now( $post_id ) {
-
-		error_log( 'maybe_publish_now: ' . $post_id . '  ---- ' . print_r( $_POST, true ) );
-
+	
 		if ( empty( $_POST['rop_publish_now_nonce'] ) ) {
 			return;
 		}

--- a/vue/src/vue-elements/pro/publish-now.vue
+++ b/vue/src/vue-elements/pro/publish-now.vue
@@ -166,7 +166,7 @@
 					return  {...(this.page_active_accounts ?? {})}?.hasOwnProperty(account_id);
 				}
 				
-				return true;
+				return ! this.choose_accounts_manually;
 			},
 		}
 	}

--- a/vue/src/vue-elements/pro/publish-now.vue
+++ b/vue/src/vue-elements/pro/publish-now.vue
@@ -163,7 +163,6 @@
 				
 				// If the active accounts for the page are set, check if the account is active for the page.
 				if ( this.page_active_accounts ) {
-					console.log({...(this.page_active_accounts ?? {})});
 					return  {...(this.page_active_accounts ?? {})}?.hasOwnProperty(account_id);
 				}
 				

--- a/vue/src/vue-elements/pro/publish-now.vue
+++ b/vue/src/vue-elements/pro/publish-now.vue
@@ -140,17 +140,17 @@
 					return;
 				}
 
-				return self.showField[value] = false;
+				return self.showField[account_id] = false;
 			},
 
 			/**
 			 * Toggle the custom share message field for a specific account.
 			 * 
-			 * @param {string} value - The ID of the account to toggle the custom share message field for.
+			 * @param {string} account_id - The ID of the account to toggle the custom share message field for.
 			 */
-			togglefields: function(value) {
+			togglefields: function(account_id) {
 				var self = this;
-				return self.showField[value] = ! self.showField[value];
+				return self.showField[account_id] = ! self.showField[account_id];
 			},
 		
 			/**
@@ -167,8 +167,7 @@
 					return  {...(this.page_active_accounts ?? {})}?.hasOwnProperty(account_id);
 				}
 				
-				// Otherwise, use the accounts active state as a fallback.
-				return {...(this.accounts ?? {})}?.[account_id]?.active;
+				return true;
 			},
 		}
 	}

--- a/vue/src/vue-elements/pro/publish-now.vue
+++ b/vue/src/vue-elements/pro/publish-now.vue
@@ -68,6 +68,11 @@
 </template>
 
 <script>
+	/**
+	 * This component is responsible for rendering the "Publish Now" section of the Pro version of the plugin.
+	 * 
+	 * The section is located in the "Publish" metabox of the post/page editor.
+	 */
 	import ButtonCheckbox from '../reusables/button-checkbox.vue'
 
 	export default {
@@ -91,7 +96,7 @@
 				choose_accounts_manually: this.$store.state.publish_now.choose_accounts_manually,
 				showField: fields,
 				toggle_accounts: this.$store.state.publish_now.instant_share_by_default,
-				active_accounts: this.$store.state.publish_now.active
+				page_active_accounts: this.$store.state.publish_now.page_active_accounts
 			}
 		},
 		computed: {
@@ -104,6 +109,12 @@
 		created() {
 		},
 		methods: {
+
+			/**
+			 * Get the class for the Font Awesome icon of a social media service.
+			 * 
+			 * @param {string} service - The slug of the social media service to get the icon for. 
+			 */
 			getServiceClass: function (service) {
 				let serviceIcon = 'fa-'
 				if (service === 'facebook') serviceIcon = serviceIcon.concat('facebook')
@@ -117,7 +128,13 @@
 				return serviceIcon;
 			},
 
-			toggleServices: function(event, value){
+			/**
+			 * Toggle the sharing feature for a specific account.
+			 * 
+			 * @param {Event} event - The toggle event.
+			 * @param {string} account_id - The ID of the account to toggle the services for.
+			 */
+			toggleServices: function(event, account_id){
 				var self = this;
 				if( event.target.checked ) {
 					return;
@@ -126,20 +143,33 @@
 				return self.showField[value] = false;
 			},
 
-			togglefields: function(value){
+			/**
+			 * Toggle the custom share message field for a specific account.
+			 * 
+			 * @param {string} value - The ID of the account to toggle the custom share message field for.
+			 */
+			togglefields: function(value) {
 				var self = this;
 				return self.showField[value] = ! self.showField[value];
 			},
-
-			containsKey(obj, key ) {
-				return Object.keys(obj).includes(key);
+		
+			/**
+			 * 
+			 * Check if the account is active for the page.
+			 * 
+			 * @param {string} account_id - The ID of the account to check the active state for.
+			 */
+			isActiveAccount: function( account_id ) {
+				
+				// If the active accounts for the page are set, check if the account is active for the page.
+				if ( this.page_active_accounts ) {
+					console.log({...(this.page_active_accounts ?? {})});
+					return  {...(this.page_active_accounts ?? {})}?.hasOwnProperty(account_id);
+				}
+				
+				// Otherwise, use the accounts active state as a fallback.
+				return {...(this.accounts ?? {})}?.[account_id]?.active;
 			},
-
-			isActiveAccount: function( key ) {
-				var self = this;
-				return this.containsKey(self.active_accounts, key);
-			},
-
 		}
 	}
 </script>


### PR DESCRIPTION
## Problem Description

1. On the page, you have meta-box where you can select which Social Media service you want to share the post.
2. Once the post is saved, the options are stored inside a post meta named `rop_publish_now_accounts` and the data looks like this: `a:1:{s:60:"twitter_aToxMzEwNTQ2NjkzMDU4OTczNjk2Ow==_1310546693058973700";s:0:"";}`

The issue is that the post meta is empty by default, thus the conditions added in this PR https://github.com/Codeinwp/tweet-old-post/pull/893 do not account for that and made the status of the check false by default.

But the users want them to be true by default. 

## Solution

Added `true` as the default value when the options are absent. 

Also changed some variables named to match their purpose. 

## Testing

- Have 2-3 accounts and activate instant sharing 
- Create a new post, you should see the the accounts as being checked by default.
- Uncheck one of the accounts, publish then reload.
- Check if the checkbox has kept it previous state. 




