### PR TITLE
fix: instant sharing default state

### DIFF
--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -796,8 +796,7 @@ class Rop_Admin {
 		global $post;
 
 		if ( in_array( $post->post_status, array( 'future', 'publish' ), true ) ) {
-			$default['action']                   = 'yes' === get_post_meta( $post->ID, 'rop_publish_now', true );
-			$default['instant_share_by_default'] = $default['action'];
+			$default['action'] = 'yes' === get_post_meta( $post->ID, 'rop_publish_now', true );
 		}
 		$default['page_active_accounts'] = get_post_meta( $post->ID, 'rop_publish_now_accounts', true );
 


### PR DESCRIPTION
## Summary

Reverting one change from https://github.com/Codeinwp/tweet-old-post/commit/1ca3f6c1c3dfc9dba5e7c69438846cfbad043da5

If the option is active, the checkbox will always be checked by default -- this was the initial behavior.

## Testing

- Active instant sharing by default in ROP > Dashboard > General Settings
- Enter a new page and check if the checkbox is checked. 