### PR TITLE
fix: run instant sharing only on published posts

### DIFF
--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -827,7 +827,7 @@ class Rop_Admin {
 		}
 
 		$post_status = get_post_status( $post_id );
-		if ( ! in_array( $post_status, array( 'future', 'publish' ), true ) ) {
+		if ( ! in_array( $post_status, array( 'publish' ), true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Closes https://github.com/Codeinwp/tweet-old-post/issues/917

## Summary

Instant sharing will now run only on posts with `published` as status. `future` has been removed from the allowed list.

## Testing

1. Install RoP with a social account.
2. Activate instant sharing.
3. Create a new post and schedule it.
4. When pressing `Schedule` that post will NOT be shared to the social account.
5. Create a new post, add some content then publish it directly. This post should be posted on the social.