### PR TITLE
fix: decode title entities

### DIFF
--- a/includes/admin/helpers/class-rop-post-format-helper.php
+++ b/includes/admin/helpers/class-rop-post-format-helper.php
@@ -270,6 +270,8 @@ class Rop_Post_Format_Helper {
 	private function build_base_content( $post_id ) {
 
 		$post_title = apply_filters( 'rop_share_post_title', get_the_title( $post_id ), $post_id );
+		$post_title = html_entity_decode( $post_title );
+
 		$post_content = apply_filters( 'rop_share_post_content', get_post_field( 'post_content', $post_id ), $post_id );
 
 		switch ( $this->post_format['post_content'] ) {


### PR DESCRIPTION
## Summary

Sometimes the title might contain encoded entities like `A Skeptic&#039;s &quot;Ghost&quot; Story – Half-Hearted Fanatic` which they should be shared like `A Skeptic's "Ghost" Story – Half-Hearted Fanatic`.

After pulling the title, I added a decoding function.

```
post_title before: A Skeptic&#8217;s &quot;Ghost&quot; Story – Half-Hearted Fanatic
post_title after: A Skeptic’s "Ghost" Story – Half-Hearted Fanatic
```

## Testing

> [!NOTE]
> To ensure you add the encoded entities, create a post using the Classic Plugin. With Gutenberg, it will make the decode automatically.

![image](https://github.com/Codeinwp/tweet-old-post/assets/17597852/08ccfde2-9aee-450c-b681-0d19862d0ee6)



1. Create a Post
2. Add the following string as a title `A Skeptic&#039;s &quot;Ghost&quot; Story – Half-Hearted Fanatic`
3. Share it with a social account.
4. The title should be displayed correctly.

