### PR TITLE
fix: update facebook graph version

### DIFF
--- a/includes/admin/services/class-rop-facebook-service.php
+++ b/includes/admin/services/class-rop-facebook-service.php
@@ -163,7 +163,7 @@ class Rop_Facebook_Service extends Rop_Services_Abstract {
 				array(
 					'app_id'                => $this->strip_whitespace( $app_id ),
 					'app_secret'            => $this->strip_whitespace( $secret ),
-					'default_graph_version' => 'v12.0',
+					'default_graph_version' => 'v16.0',
 				)
 			);
 		} catch ( Exception $exception ) {


### PR DESCRIPTION
### Summary

Updated the Facebook graph version to `16.0`, which was a deprecation date set to `02/02/2025` https://developers.facebook.com/docs/graph-api/changelog

This should prevent some problems if Facebook decides to early sunset the old APIs

### Testing

Check if you can share a post with Facebook.

Closes https://github.com/Codeinwp/tweet-old-post/issues/955