### PR TITLE
fix: update linkedin API version

### DIFF
--- a/includes/admin/services/class-rop-linkedin-service.php
+++ b/includes/admin/services/class-rop-linkedin-service.php
@@ -21,6 +21,13 @@
 class Rop_Linkedin_Service extends Rop_Services_Abstract {
 
 	/**
+	 * The version of the Linkedin API.
+	 *
+	 * @see https://learn.microsoft.com/en-us/linkedin/marketing/versioning?view=li-lms-2024-05
+	 */
+	public const LINKEDIN_VERSION = 202405;
+
+	/**
 	 * An instance of authenticated LinkedIn user.
 	 *
 	 * @since   8.0.0
@@ -573,7 +580,7 @@ class Rop_Linkedin_Service extends Rop_Services_Abstract {
 					'x-li-format'               => 'json',
 					'X-Restli-Protocol-Version' => '2.0.0',
 					'Authorization'             => 'Bearer ' . $token,
-					'Linkedin-Version'          => defined( 'ROP_LINKEDIN_VERSION' ) ? ROP_LINKEDIN_VERSION : 202304,
+					'Linkedin-Version'          => defined( 'ROP_LINKEDIN_VERSION' ) ? ROP_LINKEDIN_VERSION : self::LINKEDIN_VERSION,
 				),
 			)
 		);
@@ -971,7 +978,7 @@ class Rop_Linkedin_Service extends Rop_Services_Abstract {
 					'x-li-format'               => 'json',
 					'X-Restli-Protocol-Version' => '2.0.0',
 					'Authorization'             => 'Bearer ' . $token,
-					'Linkedin-Version'          => defined( 'ROP_LINKEDIN_VERSION' ) ? ROP_LINKEDIN_VERSION : 202304,
+					'Linkedin-Version'          => defined( 'ROP_LINKEDIN_VERSION' ) ? ROP_LINKEDIN_VERSION : self::LINKEDIN_VERSION,
 				),
 			)
 		);


### PR DESCRIPTION
## Summary

Updated the LinkedIn API version to `202405`. This should last until May 2025.

### Screenshot

![image](https://github.com/Codeinwp/tweet-old-post/assets/17597852/a4a36d6f-ff62-44c2-993a-397a60c6c7b3)

## Check before Pull Request is ready:

* [ ] ~I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/tweet-old-post-pro/issues/509
<!-- Should look like this: `Closes #1, #2, #3.` . -->