### PR TITLE
Removed start sharing button

### DIFF
--- a/vue/src/vue-elements/main-page-panel.vue
+++ b/vue/src/vue-elements/main-page-panel.vue
@@ -20,19 +20,6 @@
               target="_blank"
             >
               <b>Revive.Social</b>
-            </a> 
-            <a
-              id="rop_vid_tuts"
-              href="https://www.youtube.com/playlist?list=PLAsG7vAH40Q512C8d_0lBpVZusUQqUxuH"
-              target="_blank"
-            >
-              <span>
-                START HERE 
-                <i
-                  class="fa fa-play-circle"
-                  aria-hidden="true"
-                />
-              </span>
             </a>
           </span>
         </div>


### PR DESCRIPTION
I've removed the start sharing button from the dashboard top bar.

Close #951