### PR TITLE
Removed get support button for free users

### DIFF
--- a/includes/class-rop-i18n.php
+++ b/includes/class-rop-i18n.php
@@ -364,6 +364,7 @@ You can try to disable any of the security plugins that you use in order to see 
 					'tweet-old-post'
 				),
 				'rop_support'                => __( 'Get Support', 'tweet-old-post' ),
+				'rop_support_url'            => defined( 'ROP_PRO_BASEFILE' ) ? tsdk_support_link( ROP_PRO_BASEFILE ) : '',
 				'rop_facebook_domain_toast'  => __(
 					'You need to verify your website domain with Facebook so your shares can show as article posts on Facebook. [ <a href="https://docs.revive.social/article/1136-facebook-text-posts-vs-article-posts" target="_blank">Read this doc</a> ] for more information',
 					'tweet-old-post'

--- a/vue/src/vue-elements/main-page-panel.vue
+++ b/vue/src/vue-elements/main-page-panel.vue
@@ -168,12 +168,6 @@
             class="btn rop-sidebar-action-btns"
           >{{ labels.rop_support }}</a>
           <a
-            v-if="license < 1"
-            href="https://revive.social/support/"
-            target="_blank"
-            class="btn rop-sidebar-action-btns"
-          >{{ labels.rop_support }}</a>
-          <a
             v-if="haveAccounts"
             href="https://docs.revive.social/"
             target="_blank"

--- a/vue/src/vue-elements/main-page-panel.vue
+++ b/vue/src/vue-elements/main-page-panel.vue
@@ -162,7 +162,7 @@
             <upsell-sidebar />
           </div>
           <a
-            v-if="license >= 1"
+            v-if="license >= 1 && labels.rop_support_url !== ''"
             :href="labels.rop_support_url"
             target="_blank"
             class="btn rop-sidebar-action-btns"

--- a/vue/src/vue-elements/main-page-panel.vue
+++ b/vue/src/vue-elements/main-page-panel.vue
@@ -163,7 +163,7 @@
           </div>
           <a
             v-if="license >= 1"
-            href="https://revive.social/pro-support/"
+            :href="labels.rop_support_url"
             target="_blank"
             class="btn rop-sidebar-action-btns"
           >{{ labels.rop_support }}</a>


### PR DESCRIPTION
I've removed the `Get Support` button from the sidebar for free users.

Close Codeinwp/tweet-old-post-pro#514