### PR TITLE
Removed plugin roadmap submenu

### DIFF
--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -659,14 +659,6 @@ class Rop_Admin {
 				'rop_addons_page',
 			)
 		);
-
-		add_submenu_page(
-			'TweetOldPost',
-			__( 'Roadmap', 'tweet-old-post' ),
-			__( 'Plugin Roadmap', 'tweet-old-post' ),
-			'manage_options',
-			'https://trello.com/b/svAZqXO1/roadmap-revive-old-posts'
-		);
 	}
 
 	/**


### PR DESCRIPTION
I've removed the plugin roadmap submenu with this PR

Close https://github.com/Codeinwp/tweet-old-post-pro/issues/511