### PR TITLE
feat: add Yoast title & description

### DIFF
--- a/includes/admin/helpers/class-rop-post-format-helper.php
+++ b/includes/admin/helpers/class-rop-post-format-helper.php
@@ -316,6 +316,22 @@ class Rop_Post_Format_Helper {
 					$content = $post_content;
 				}
 				break;
+			case 'yoast_seo_title_description':
+				if ( function_exists( 'YoastSEO' ) ) {
+					$title       = YoastSEO()->meta->for_post( $post_id )->title;
+					$description = YoastSEO()->meta->for_post( $post_id )->description;
+
+					// This is empty if user doesn't add a custom description
+					// So lets fall back to post content
+					if ( empty( $description ) ) {
+						$description = $post_content;
+					}
+
+					$content = $title . ' ' . $description;
+				} else {
+					$content = $post_title . apply_filters( 'rop_title_content_separator', ' ' ) . $post_content;
+				}
+				break;
 			default:
 				$content = $post_title;
 				break;

--- a/includes/class-rop-i18n.php
+++ b/includes/class-rop-i18n.php
@@ -225,6 +225,7 @@ class Rop_I18n {
 				'post_content_option_custom_field'  => __( 'Custom Field', 'tweet-old-post' ),
 				'post_content_option_yoast_seo_title'  => __( 'Yoast SEO Title', 'tweet-old-post' ),
 				'post_content_option_yoast_seo_description' => __( 'Yoast SEO Description', 'tweet-old-post' ),
+				'post_content_option_yoast_seo_title_description' => __( 'Yoast SEO Title & Description', 'tweet-old-post' ),
 				'custom_meta_title'                 => __( 'Custom Meta Field', 'tweet-old-post' ),
 				'custom_meta_desc'                  => __( 'Meta field name from which to get the content.', 'tweet-old-post' ),
 				'max_char_title'                    => __( 'Maximum Characters', 'tweet-old-post' ),

--- a/vue/src/vue-elements/post-format.vue
+++ b/vue/src/vue-elements/post-format.vue
@@ -85,6 +85,13 @@
             >
               {{ labels.post_content_option_yoast_seo_description }} {{ !isPro ? "(Pro)" : '' }}
             </option>
+            <option
+              v-if="yoast_seo_active_status"
+              value="yoast_seo_title_description"
+              :disabled="!isPro"
+            >
+              {{ labels.post_content_option_yoast_seo_title_description }} {{ !isPro ? "(Pro)" : '' }}
+            </option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Add Yoast Title & Description as an option for `Share Content` options.

## Screenshots

<img width="1207" alt="Screenshot 2024-07-10 at 18 17 36" src="https://github.com/Codeinwp/tweet-old-post/assets/17597852/337c4052-e9b8-42f7-b6a5-46399d0bd08a">

## Testing

1. Install Yoast
2. Choose `Yoast Title & Description` for `Share Content`.
3. Share a post. It should include both title and description from Yoast.