### PR TITLE
Fixed icons font family issue with japanese/chinese lang

### DIFF
--- a/assets/css/rop_core.css
+++ b/assets/css/rop_core.css
@@ -4835,3 +4835,10 @@ padding: 0 20px;
 #rop_core .uppercase {
     text-transform: uppercase;
 }
+
+#rop_core i.fa {
+    font-family: 'FontAwesome';
+}
+#rop_core span.dashicons {
+    font-family: 'dashicons';
+}


### PR DESCRIPTION
I've fixed the `font-awesome` and `dash icons` font family issues.

Close #824