### PR TITLE
fix: maintain backwards compatibility

### DIFF
--- a/includes/admin/models/class-rop-services-model.php
+++ b/includes/admin/models/class-rop-services-model.php
@@ -550,7 +550,7 @@ class Rop_Services_Model extends Rop_Model_Abstract {
 	 * @param string $key The key to retrieve from model data.
 	 *
 	 * @return mixed
-	 * @since   8.0.0
+	 * @since   9.1.0
 	 * @access  protected
 	 */
 	protected function get( $key ) {
@@ -596,7 +596,9 @@ class Rop_Services_Model extends Rop_Model_Abstract {
 	 * To maintain backward compatibility, we will save the webhooks in a separate namespace.
 	 *
 	 * @param string $key The key to save.
-	 * @param array $value The value to save.
+	 * @param array  $value The value to save.
+	 *
+	 * @since 9.1.0
 	 *
 	 * @return array The value to save.
 	 */

--- a/includes/admin/services/class-rop-webhook-service.php
+++ b/includes/admin/services/class-rop-webhook-service.php
@@ -85,8 +85,7 @@ class Rop_Webhook_Service extends Rop_Services_Abstract {
 	 * @return mixed
 	 */
 	public function share( $post_details, $args = array() ) {
-
-		$log_account_used = '[' . $this->credentials['user'] . '] ';
+		$log_account_used = '[' . $this->display_name . '] ';
 		if ( Rop_Admin::rop_site_is_staging( $post_details['post_id'] ) ) {
 			$this->logger->alert_error( $log_account_used . Rop_I18n::get_labels( 'sharing.share_attempted_on_staging' ) );
 			return false;

--- a/includes/admin/services/class-rop-webhook-service.php
+++ b/includes/admin/services/class-rop-webhook-service.php
@@ -21,6 +21,15 @@
 class Rop_Webhook_Service extends Rop_Services_Abstract {
 
 	/**
+	 * Defines the service slug.
+	 *
+	 * @since   9.1.0
+	 * @access  public
+	 * @var     string SERVICE_SLUG The service slug.
+	 */
+	public const SERVICE_SLUG = 'webhook';
+
+	/**
 	 * Defines the service name in slug format.
 	 *
 	 * @since   9.1.0

--- a/tests/test-accounts.php
+++ b/tests/test-accounts.php
@@ -141,6 +141,22 @@ class Test_RopAccounts extends WP_UnitTestCase {
 		}
 
 		$this->assertTrue( $account_added );
+
+		$saved_data = get_option( 'rop_data', array() );
+		
+		$webhooks_services = $saved_data[Rop_Services_Model::WEBHOOK_NAMESPACE];
+		$this->assertNotEmpty( $webhooks_services );
+		foreach ( $webhooks_services as $webhook_service_id => $webhook_service ) {
+			$this->assertEquals( $webhook_service['credentials']['url'], $webhook_data['url'] );
+			$this->assertEquals( $webhook_service['credentials']['display_name'], $webhook_data['display_name'] );
+			$this->assertEquals( $webhook_service['credentials']['headers'], $webhook_data['headers'] );
+		}
+
+		// No webhooks saved in the main services array. Backwards compatibility!
+		$services = $saved_data['services'];
+		foreach ( $services as $service_key => $service ) {
+			$this->assertNotEquals( Rop_Webhook_Service::SERVICE_SLUG, $service['service'] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Add backward compatibility for webhook services.

Instead of being saved in `rop_data.services`, they will be saved in `rop_data.services_webhooks`! (same thing for active accounts)

The `set` and `get` functions have been modified to ensure that pulling and saving the data are the same for the whole program, even if the data is from two different sources.

> [!NOTE]
> THe way we merge the data is by making the webhooks always appear first in the Dashboard. If this bothers someone, the accounts can be sorted by the creation date.

### Testing

Use the build from this PR together with https://github.com/Codeinwp/tweet-old-post-pro/pull/537

1. Add a webhook. 
2. Switch to the current ROP version.
3. No crash should happen. 