### PR TITLE
Upgrade facebook graph api version

### DIFF
--- a/includes/admin/services/class-rop-facebook-service.php
+++ b/includes/admin/services/class-rop-facebook-service.php
@@ -761,9 +761,9 @@ class Rop_Facebook_Service extends Rop_Services_Abstract {
 			$post_data['access_token'] = $token;
 
 			if ( 'video' === $posting_type ) {
-				$url = 'https://graph-video.facebook.com/v12.0' . $path;
+				$url = 'https://graph-video.facebook.com/v16.0' . $path;
 			} else {
-				$url = 'https://graph.facebook.com/v12.0' . $path;
+				$url = 'https://graph.facebook.com/v16.0' . $path;
 			}
 
 			// Scrape post URL before sharing

--- a/includes/admin/services/class-rop-facebook-service.php
+++ b/includes/admin/services/class-rop-facebook-service.php
@@ -163,7 +163,7 @@ class Rop_Facebook_Service extends Rop_Services_Abstract {
 				array(
 					'app_id'                => $this->strip_whitespace( $app_id ),
 					'app_secret'            => $this->strip_whitespace( $secret ),
-					'default_graph_version' => 'v16.0',
+					'default_graph_version' => 'v20.0',
 				)
 			);
 		} catch ( Exception $exception ) {
@@ -761,9 +761,9 @@ class Rop_Facebook_Service extends Rop_Services_Abstract {
 			$post_data['access_token'] = $token;
 
 			if ( 'video' === $posting_type ) {
-				$url = 'https://graph-video.facebook.com/v16.0' . $path;
+				$url = 'https://graph-video.facebook.com/v20.0' . $path;
 			} else {
-				$url = 'https://graph.facebook.com/v16.0' . $path;
+				$url = 'https://graph.facebook.com/v20.0' . $path;
 			}
 
 			// Scrape post URL before sharing


### PR DESCRIPTION
I've changed the Facebook graph API version `v12.0` to `v16.0` and our ROP APP supports the `v16.0` graph version.
Ref: https://github.com/search?q=repo%3ACodeinwp%2Frop-auth-service%20default_graph_version&type=code

Version `v16.0` is available until `May 14, 2025`

![image](https://github.com/user-attachments/assets/1ffa35d6-41d6-4057-afb0-2c41a6b95610)
