### PR TITLE
fix: Share as image not working for Twitter

### DIFF
--- a/includes/admin/services/class-rop-twitter-service.php
+++ b/includes/admin/services/class-rop-twitter-service.php
@@ -500,7 +500,6 @@ class Rop_Twitter_Service extends Rop_Services_Abstract {
 			'media_category' => 'tweet_image',
 		);
 
-
 		$options['chunkedUpload'] = false;
 
 		if ( ! empty( $photon_bypass ) && class_exists( 'Jetpack_Photon' ) ) {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Changes required for: https://github.com/Codeinwp/twitteroauth/pull/5

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/tweet-old-post-pro/issues/603.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
