### PR TITLE
fix: options visibility when gutenberg is disabled

### DIFF
--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -751,6 +751,7 @@ class Rop_Admin {
 	 *
 	 * This is quite complex as it needs to check various conditions:
 	 * - If the Classic Editor plugin is active.
+	 * - If the Disabled Gutenberg plugin is active.
 	 * - If the post is saved with the Classic Editor.
 	 * - If the user has selected the Classic Editor in their profile.
 	 * - If the post is a new post (post_id is 0).
@@ -764,6 +765,11 @@ class Rop_Admin {
 	public static function is_classic_editor() {
 		if ( isset( $_GET['wpb-backend-editor'] ) ) {
 			// If the wpb-backend-editor is set, we are using the classic editor via WPBakery.
+			return true;
+		}
+
+		// disable-gutenberg plugin is active.
+		if ( class_exists( 'DisableGutenberg' ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
### Summary
Fixed the revive social options are hidden when the disabled Gutenberg plugin is activated.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/tweet-old-post-pro/issues/611