### PR TITLE
fix: update ThemeIsle link domain in sale URL

### DIFF
--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -1933,7 +1933,7 @@ class Rop_Admin {
 		$config['message']  = sprintf( $message_template, '<strong>', $discount, '</strong>', $product_label );
 		$config['sale_url'] = add_query_arg(
 			$url_params,
-			tsdk_translate_link( tsdk_utmify( 'https://themeisle.com/rs-bf', 'bfcm', 'revive' ) )
+			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/rs-bf', 'bfcm', 'revive' ) )
 		);
 
 		$configs[ ROP_PRODUCT_SLUG ] = $config;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Use `.link` instead of `.com`.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check the link to redirect to Black Friday sale.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
