### PR TITLE
fix: update sharing status label

### DIFF
--- a/vue/src/vue-elements/reusables/status-box.vue
+++ b/vue/src/vue-elements/reusables/status-box.vue
@@ -56,11 +56,12 @@ export default {
       required: true
     }
   },
-  data() {
-    const [ title, description ] = this.label.split( ':' )
-    return {
-      title,
-      description
+  computed: {
+    title() {
+      return this.label.split(':')[0]
+    },
+    description() {
+      return this.label.split(':')[1]
     }
   }
 }


### PR DESCRIPTION
### Summary
Implemented a computed property to update the label of the sharing status.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/tweet-old-post/issues/1048