### PR TITLE
refactor: update Black Friday labels

### DIFF
--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -1943,6 +1943,8 @@ class Rop_Admin {
 		} else {
 			// translators: %s - discount.
 			$config['title'] = sprintf( __( 'Revive Social Pro: %s off this week', 'tweet-old-post' ), '60%' );
+			// translators: %s - discount.
+			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'tweet-old-post' ), '60%' );
 		}
 
 		$url_params    = array(

--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -1908,29 +1908,35 @@ class Rop_Admin {
 	public static function add_black_friday_data( $configs ) {
 		$config = $configs['default'];
 
-		// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-		$message_template = __( 'Our biggest sale of the year: %1$sup to %2$s OFF%3$s on %4$s. Don\'t miss this limited-time offer.', 'tweet-old-post' );
-		$product_label    = __( 'Revive Social', 'tweet-old-post' );
-		$discount         = '50%';
+		$message = __( 'Custom schedules, multiple accounts, analytics. Automate your social sharing properly. Exclusively for existing Revive Social users.', 'tweet-old-post' );
+		$cta_label = __( 'Get Revive Social Pro', 'tweet-old-post' );
 
 		$plan    = apply_filters( 'product_rop_license_plan', 0 );
 		$license = apply_filters( 'product_rop_license_key', false );
-		$is_pro  = 0 < $plan;
+		$status  = apply_filters( 'product_rop_license_status', false );
+		$is_pro  = 'valid' === $status;
+		$is_expired = 'expired' === $status || 'active-expired' === $status;
 
 		if ( $is_pro ) {
-			// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-			$message_template = __( 'Get %1$sup to %2$s off%3$s when you upgrade your %4$s plan or renew early.', 'tweet-old-post' );
-			$product_label    = __( 'Revive Social Pro', 'tweet-old-post' );
-			$discount         = '20%';
+			// translators: %1$s - discount, %2$s - discount.
+			$message = sprintf( __( 'Upgrade your Revive Social Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'tweet-old-post' ), '30%', '20%' );
+			$cta_label = __( 'See your options', 'tweet-old-post' );
+		} elseif ( $is_expired ) {
+			$message = __( 'Your Revive Social Pro features are still here, just locked. Renew at a reduced rate this week.', 'tweet-old-post' );
+			$cta_label = __( 'Reactivate now', 'tweet-old-post' );
+		} else {
+			// translators: %s - discount.
+			$config['title'] = sprintf( __( 'Revive Social Pro: %s off this week', 'tweet-old-post' ), '60%' );
 		}
 
-		$product_label = sprintf( '<strong>%s</strong>', $product_label );
 		$url_params    = array(
 			'utm_term' => $is_pro ? 'plan-' . $plan : 'free',
 			'lkey'     => ! empty( $license ) ? $license : false,
+			'expired'  => $is_expired ? '1' : false,
 		);
 
-		$config['message']  = sprintf( $message_template, '<strong>', $discount, '</strong>', $product_label );
+		$config['message']  = $message;
+		$config['cta_label'] = $cta_label;
 		$config['sale_url'] = add_query_arg(
 			$url_params,
 			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/rs-bf', 'bfcm', 'revive' ) )

--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -1925,9 +1925,11 @@ class Rop_Admin {
 
 		$pro_product_slug = defined( 'ROP_PRO_BASEFILE' ) ? basename( dirname( ROP_PRO_BASEFILE ) ) : '';
 		if ( $is_pro || $is_expired ) {
+			// translators: %s is the discount percentage.
 			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'tweet-old-post' ), '30%' );
 			$config['plugin_meta_targets'] = array( $pro_product_slug );
 		} else {
+			// translators: %s is the discount percentage.
 			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'tweet-old-post' ), '60%' );
 		}
 

--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -1852,6 +1852,12 @@ class Rop_Admin {
 	 * @return array
 	 */
 	public function rop_upgrade_to_pro_plugin_action( $actions, $plugin_file ) {
+
+		$is_black_friday = apply_filters( 'themeisle_sdk_is_black_friday_sale', false );
+		if ( $is_black_friday ) {
+			return $actions;
+		}
+
 		$global_settings     = new \Rop_Global_Settings();
 		$actions['settings'] = '<a href="' . admin_url( 'admin.php?page=TweetOldPost' ) . '">' . __( 'Settings', 'tweet-old-post' ) . '</a>';
 		if ( $global_settings->license_type() < 1 ) {
@@ -1916,6 +1922,14 @@ class Rop_Admin {
 		$status  = apply_filters( 'product_rop_license_status', false );
 		$is_pro  = 'valid' === $status;
 		$is_expired = 'expired' === $status || 'active-expired' === $status;
+
+		$pro_product_slug = defined( 'ROP_PRO_BASEFILE' ) ? basename( dirname( ROP_PRO_BASEFILE ) ) : '';
+		if ( $is_pro || $is_expired ) {
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'tweet-old-post' ), '30%' );
+			$config['plugin_meta_targets'] = array( $pro_product_slug );
+		} else {
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'tweet-old-post' ), '60%' );
+		}
 
 		if ( $is_pro ) {
 			// translators: %1$s - discount, %2$s - discount.

--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -1924,23 +1924,27 @@ class Rop_Admin {
 		$is_expired = 'expired' === $status || 'active-expired' === $status;
 
 		$pro_product_slug = defined( 'ROP_PRO_BASEFILE' ) ? basename( dirname( ROP_PRO_BASEFILE ) ) : '';
+
 		if ( $is_pro || $is_expired ) {
-			// translators: %s is the discount percentage.
-			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'tweet-old-post' ), '30%' );
 			$config['plugin_meta_targets'] = array( $pro_product_slug );
-		} else {
-			// translators: %s is the discount percentage.
-			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'tweet-old-post' ), '60%' );
 		}
 
 		if ( $is_pro ) {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'tweet-old-post' ), '30%' );
 			// translators: %1$s - discount, %2$s - discount.
 			$message = sprintf( __( 'Upgrade your Revive Social Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'tweet-old-post' ), '30%', '20%' );
 			$cta_label = __( 'See your options', 'tweet-old-post' );
 		} elseif ( $is_expired ) {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'tweet-old-post' ), '50%' );
+			// translators: %s - discount.
+			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'tweet-old-post' ), '50%' );
 			$message = __( 'Your Revive Social Pro features are still here, just locked. Renew at a reduced rate this week.', 'tweet-old-post' );
 			$cta_label = __( 'Reactivate now', 'tweet-old-post' );
 		} else {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'tweet-old-post' ), '50%' );
 			// translators: %s - discount.
 			$config['title'] = sprintf( __( 'Revive Social Pro: %s off this week', 'tweet-old-post' ), '60%' );
 			// translators: %s - discount.


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Change the labels for Black Friday promotion. Based on https://github.com/Codeinwp/themeisle/issues/1854

### Screenshots <!-- if applicable -->


<img width="2236" height="1752" alt="CleanShot 2026-03-17 at 14 13 46@2x" src="https://github.com/user-attachments/assets/2e961040-aa40-4db8-a7dd-19128fbad7f5" />
<img width="2248" height="1532" alt="CleanShot 2026-03-17 at 14 14 34@2x" src="https://github.com/user-attachments/assets/83a346ea-8a11-4a52-a114-bd3706c20927" />
<img width="2238" height="1504" alt="CleanShot 2026-03-17 at 14 15 13@2x" src="https://github.com/user-attachments/assets/e9ca335e-3722-43d0-a730-848f1c13d621" />


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this plugin: https://github.com/Soare-Robert-Daniel/test-black-friday
- Use this SDK version: https://github.com/Codeinwp/themeisle-sdk-main/pull/309
- Test:
  - If the notice appears during the Black Friday period.
  - If the labels change based on the license status (described in the spreadsheet)
  - If the notice can be dismissed.
  - If the notice appears only if the plugin is 3 days old. Warning: You will see the notice if you have another product that is older than 3 days; in this case, better to disable them.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1854
<!-- Should look like this: `Closes #1, #2, #3.` . -->
