### PR TITLE
fix: Bluesky link card repeats the post caption as the embed description

### DIFF
--- a/includes/admin/helpers/class-rop-bluesky-api.php
+++ b/includes/admin/helpers/class-rop-bluesky-api.php
@@ -504,7 +504,7 @@ class Rop_Bluesky_Api {
 			'external' => array(
 				'uri'         => $post['post_url'],
 				'title'       => isset( $post['title'] ) ? $post['title'] : '',
-				'description' => isset( $post['content'] ) ? $post['content'] : '',
+				'description' => '',
 			),
 		);
 	}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -46,6 +46,9 @@
         <testsuite name="bluesky-image">
             <directory>./tests/test-bluesky-image.php</directory>
         </testsuite>
+        <testsuite name="bluesky-card">
+            <directory>./tests/test-bluesky-card.php</directory>
+        </testsuite>
         <testsuite name="x-premium-limit">
             <directory>./tests/test-x-premium-limit.php</directory>
         </testsuite>

--- a/tests/test-bluesky-card.php
+++ b/tests/test-bluesky-card.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * ROP Test Bluesky link card embed for PHPUnit.
+ *
+ * Reproduces GitHub issue Codeinwp/tweet-old-post-pro#676: the link card
+ * (app.bsky.embed.external) must not repeat the post caption as its
+ * description — Bluesky renders cards without a description as title + domain.
+ *
+ * @package     ROP
+ * @subpackage  Tests
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Test Bluesky link card. class.
+ */
+class Test_RopBlueskyCard extends WP_UnitTestCase {
+
+	/**
+	 * The link card description must be empty, not a copy of the post body.
+	 *
+	 * @covers Rop_Bluesky_Api::create_post
+	 */
+	public function test_link_card_description_is_empty() {
+		$captured = null;
+
+		$interceptor = function ( $preempt, $args, $url ) use ( &$captured ) {
+			if ( false === strpos( $url, 'com.atproto.repo.createRecord' ) ) {
+				return $preempt;
+			}
+			$captured = json_decode( $args['body'], true );
+
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode(
+					array(
+						'uri' => 'at://did:plc:test/app.bsky.feed.post/test',
+						'cid' => 'test-cid',
+					)
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $interceptor, 10, 3 );
+
+		$api = new Rop_Bluesky_Api( 'test.bsky.social', 'test-app-password' );
+		$api->create_post(
+			'did:plc:test',
+			array(
+				'content'  => 'My caption text for this share.',
+				'title'    => 'My Post Title',
+				'post_url' => 'https://example.org/my-post/',
+			),
+			'link',
+			'',
+			'test-access-token'
+		);
+
+		remove_filter( 'pre_http_request', $interceptor, 10 );
+
+		$this->assertNotNull( $captured, 'create_post() should have attempted a createRecord request.' );
+
+		$embed = $captured['record']['embed'];
+		$this->assertSame( 'app.bsky.embed.external', $embed['$type'] );
+		$this->assertSame( 'https://example.org/my-post/', $embed['external']['uri'] );
+		$this->assertSame( 'My Post Title', $embed['external']['title'] );
+		$this->assertSame(
+			'',
+			$embed['external']['description'],
+			'Link card description must be empty, not a duplicate of the post caption (issue #676).'
+		);
+	}
+}


### PR DESCRIPTION
Fixes Codeinwp/tweet-old-post-pro#676

### Changes
- **`class-rop-bluesky-api.php`** — the external embed (`app.bsky.embed.external`) description is now empty instead of duplicating `$post['content']`, which is already sent as the post text. Bluesky renders the card as title + domain, like any page without an OG description. Covers both call sites: link posts and image posts with a URL. The `description` key stays present (empty string) since the AT Protocol lexicon requires it.
- Excerpts were deliberately not used: WordPress auto-generates missing excerpts from the post content, which would reintroduce the duplication for most posts.

### Tests
New `bluesky-card` PHPUnit suite captures the outbound `createRecord` request (`pre_http_request`, no Bluesky account needed): fails on the old code, passes with the fix. 

