### PR TITLE
Enforced maximum post age when sharing queued posts

### DIFF
--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -1240,7 +1240,6 @@ class Rop_Admin {
 
 								if ( ! $posts_selector_model->is_post_eligible( $post ) ) {
 									$logger->info( ucfirst( $account_data['service'] ) . ': ' . Rop_I18n::get_labels( 'sharing.post_not_eligible' ), array( 'extra' => array( 'post_id' => $post ) ) );
-									$posts_selector_model->update_buffer( $account, $post );
 									continue;
 								}
 

--- a/includes/admin/class-rop-admin.php
+++ b/includes/admin/class-rop-admin.php
@@ -1238,6 +1238,12 @@ class Rop_Admin {
 									continue;
 								}
 
+								if ( ! $posts_selector_model->is_post_eligible( $post ) ) {
+									$logger->info( ucfirst( $account_data['service'] ) . ': ' . Rop_I18n::get_labels( 'sharing.post_not_eligible' ), array( 'extra' => array( 'post_id' => $post ) ) );
+									$posts_selector_model->update_buffer( $account, $post );
+									continue;
+								}
+
 								do_action( 'rop_before_prepare_post', $post );
 								$post_data = $queue->prepare_post_object( $post, $account );
 

--- a/includes/admin/models/class-rop-posts-selector-model.php
+++ b/includes/admin/models/class-rop-posts-selector-model.php
@@ -633,9 +633,9 @@ class Rop_Posts_Selector_Model extends Rop_Model_Abstract {
 		if ( ! empty( $min_age ) ) {
 			$args['date_query'][]['before'] = date( 'Y-m-d', strtotime( '-' . $this->settings->get_minimum_post_age() . ' days' ) );
 		}
-		$max_age = $this->settings->get_maximum_post_age();
-		if ( ! empty( $max_age ) ) {
-			$args['date_query'][]['after'] = date( 'Y-m-d', strtotime( '-' . $this->settings->get_maximum_post_age() . ' days' ) );
+		$max_age_date = $this->get_maximum_post_age_date();
+		if ( ! empty( $max_age_date ) ) {
+			$args['date_query'][]['after'] = $max_age_date;
 		}
 		if ( ! empty( $args['date_query'] ) ) {
 			$args['date_query']['relation'] = 'AND';
@@ -645,6 +645,75 @@ class Rop_Posts_Selector_Model extends Rop_Model_Abstract {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Utility method to get the maximum post age date.
+	 *
+	 * @return string The boundary date in `Y-m-d` format, or an empty string when no maximum age is set.
+	 * @access  private
+	 */
+	private function get_maximum_post_age_date() {
+		$max_age = $this->settings->get_maximum_post_age();
+		if ( empty( $max_age ) ) {
+			return '';
+		}
+
+		return date( 'Y-m-d', strtotime( '-' . $max_age . ' days' ) );
+	}
+
+	/**
+	 * Method to check if a post still satisfies the maximum post age setting.
+	 *
+	 * @param int $post_id The post ID to check.
+	 *
+	 * @return bool True when no maximum age is set or the post is still young enough.
+	 * @access  public
+	 */
+	public function is_post_within_maximum_age( $post_id ) {
+		$max_age_date = $this->get_maximum_post_age_date();
+		if ( empty( $max_age_date ) ) {
+			return true;
+		}
+
+		$post_date = get_post_field( 'post_date', $post_id );
+		if ( empty( $post_date ) ) {
+			return false;
+		}
+
+		return strtotime( $post_date ) > strtotime( $max_age_date );
+	}
+
+	/**
+	 * Method to check whether a post is still eligible for sharing.
+	 *
+	 * @param int $post_id The post ID to check.
+	 *
+	 * @return bool
+	 * @access  public
+	 */
+	public function is_post_eligible( $post_id ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post instanceof WP_Post ) {
+			$eligible = false;
+		} else {
+			// The statuses the selector query allows, `inherit` covers attachments.
+			$allowed_statuses = array( 'publish' );
+			if ( 'attachment' === $post->post_type ) {
+				$allowed_statuses[] = 'inherit';
+			}
+
+			$eligible = in_array( $post->post_status, $allowed_statuses, true ) && $this->is_post_within_maximum_age( $post_id );
+		}
+
+		/**
+		 * Filters whether an already queued post is still eligible for sharing.
+		 *
+		 * @param bool $eligible Whether the post is eligible.
+		 * @param int  $post_id  The post ID being checked.
+		 */
+		return (bool) apply_filters( 'rop_is_post_eligible', $eligible, $post_id );
 	}
 
 	/**

--- a/includes/class-rop-i18n.php
+++ b/includes/class-rop-i18n.php
@@ -499,6 +499,7 @@ You can try to disable any of the security plugins that you use in order to see 
 
 			'sharing' => array(
 				'post_already_shared' => __( 'This post went out on the last share event and might be a duplicate. Skipping...', 'tweet-old-post' ),
+				'post_not_eligible' => __( 'This post is no longer eligible for sharing. It might have been deleted, unpublished, or become older than the maximum post age. Skipping...', 'tweet-old-post' ),
 				'share_attempted_on_staging' => __( 'Revive Social has detected that this is a development website. Share process skipped.', 'tweet-old-post' ),
 				'reached_sharing_limit' => __( 'You\'ve reached your daily post sharing limit of %1$d posts. Want to share more? Consider upgrading to enjoy a higher limit.', 'tweet-old-post' ),
 				'invalid_license' => __( 'Sorry, your license is invalid.', 'tweet-old-post' ),

--- a/tests/test-queue.php
+++ b/tests/test-queue.php
@@ -141,4 +141,132 @@ class Test_RopQueue extends WP_UnitTestCase {
 		$this->assertEquals( 0, count( $ordered_queue ), 'Ordered queue should be empty if the start sharing is not active' );
 	}
 
+	/**
+	 * Utility method to move a post publish date back in time.
+	 *
+	 * @param int    $post_id The post to age.
+	 * @param string $shift The relative date shift, eg. `-400 days`.
+	 */
+	private function age_post( $post_id, $shift ) {
+		$date = date( 'Y-m-d H:i:s', strtotime( $shift ) );
+		wp_update_post(
+			array(
+				'ID'            => $post_id,
+				'post_date'     => $date,
+				'post_date_gmt' => get_gmt_from_date( $date ),
+				'edit_date'     => true,
+			)
+		);
+		clean_post_cache( $post_id );
+	}
+
+	/**
+	 * Test the eligibility check used before a queued post is shared.
+	 *
+	 * @covers Rop_Posts_Selector_Model::is_post_eligible
+	 * @covers Rop_Posts_Selector_Model::is_post_within_maximum_age
+	 */
+	public function test_post_eligibility() {
+		$selector = new Rop_Posts_Selector_Model();
+		$settings = new Rop_Settings_Model();
+
+		$max_age = $settings->get_maximum_post_age();
+		$this->assertNotEmpty( $max_age, 'This test needs a maximum post age to be set.' );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '-' . ( $max_age - 5 ) . ' days' ) ),
+			)
+		);
+
+		$this->assertTrue( $selector->is_post_within_maximum_age( $post_id ), 'A post younger than the maximum age should satisfy the age check.' );
+		$this->assertTrue( $selector->is_post_eligible( $post_id ), 'A published post within the maximum age should be eligible.' );
+
+		$this->age_post( $post_id, '-' . ( $max_age + 5 ) . ' days' );
+		$this->assertFalse( $selector->is_post_within_maximum_age( $post_id ), 'A post older than the maximum age should fail the age check.' );
+		$this->assertFalse( $selector->is_post_eligible( $post_id ), 'A post older than the maximum age should not be eligible.' );
+
+		$draft_id = self::factory()->post->create(
+			array(
+				'post_status' => 'draft',
+				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '-2 month' ) ),
+			)
+		);
+		$this->assertFalse( $selector->is_post_eligible( $draft_id ), 'An unpublished post should not be eligible.' );
+
+		$deleted_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		wp_delete_post( $deleted_id, true );
+		$this->assertFalse( $selector->is_post_eligible( $deleted_id ), 'A deleted post should not be eligible.' );
+	}
+
+	/**
+	 * Test that a post which was eligible when queued is not shared once it
+	 * exceeds the maximum post age.
+	 *
+	 * @covers Rop_Admin::rop_cron_job
+	 */
+	public function test_queued_post_exceeding_max_age_is_not_shared() {
+		$account_id = Rop_InitAccounts::get_account_id();
+		$queue      = new Rop_Queue_Model();
+		$scheduler  = new Rop_Scheduler_Model();
+		$settings   = new Rop_Settings_Model();
+
+		$settings_data                    = $settings->get_settings();
+		$original_no_of_posts             = $settings_data['number_of_posts'];
+		$settings_data['number_of_posts'] = 1;
+		$settings->save_settings( $settings_data );
+
+		$built = $queue->build_queue();
+		$this->assertArrayHasKey( $account_id, $built, 'The account should have a queue.' );
+		$this->assertNotEmpty( $built[ $account_id ][0]['posts'], 'The first queue event should hold a post.' );
+
+		$queued_post = $built[ $account_id ][0]['posts'][0];
+
+		$selector = new Rop_Posts_Selector_Model();
+		$this->assertTrue( $selector->is_post_eligible( $queued_post ), 'The queued post should have been eligible when it was queued.' );
+
+		$this->age_post( $queued_post, '-' . ( $settings->get_maximum_post_age() + 10 ) . ' days' );
+
+		$this->assertContains( $queued_post, $queue->build_queue()[ $account_id ][0]['posts'], 'The queue should still hold the aged post.' );
+
+		$events    = $scheduler->get_upcoming_events( $account_id );
+		$events[0] = Rop_Scheduler_Model::get_current_time() - MINUTE_IN_SECONDS;
+		$scheduler->update_timeline( $events, $account_id );
+
+		$prepared = array();
+		$recorder = function ( $post_id ) use ( &$prepared ) {
+			$prepared[] = $post_id;
+		};
+		add_action( 'rop_before_prepare_post', $recorder );
+
+		$checked = array();
+		$spy     = function ( $eligible, $post_id ) use ( &$checked ) {
+			$checked[ $post_id ] = $eligible;
+
+			return $eligible;
+		};
+		add_filter( 'rop_is_post_eligible', $spy, 10, 2 );
+
+		$admin = new Rop_Admin();
+		$admin->rop_cron_job();
+
+		remove_action( 'rop_before_prepare_post', $recorder );
+		remove_filter( 'rop_is_post_eligible', $spy, 10 );
+
+		$this->assertArrayHasKey( $queued_post, $checked, 'The sharing job should re-validate the queued post before sharing it.' );
+		$this->assertFalse( $checked[ $queued_post ], 'The aged post should be reported as not eligible.' );
+		$this->assertNotContains( $queued_post, $prepared, 'A post older than the maximum post age must not be shared.' );
+
+		$refreshed     = ( new Rop_Queue_Model() )->build_queue();
+		$queued_posts  = array();
+		foreach ( $refreshed[ $account_id ] as $event ) {
+			$queued_posts = array_merge( $queued_posts, $event['posts'] );
+		}
+		$this->assertNotContains( $queued_post, $queued_posts, 'The skipped post should be removed from the queue.' );
+
+		$settings_data['number_of_posts'] = $original_no_of_posts;
+		$settings->save_settings( $settings_data );
+	}
+
 }


### PR DESCRIPTION
### Summary
Revalidate queued posts before sharing them to ensure they are still eligible at the time of sharing, preventing posts that became ineligible after being queued from being shared.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/tweet-old-post/issues/1101