### PR TITLE
Improved API response handling to prevent data loss

### DIFF
--- a/includes/admin/class-rop-rest-api.php
+++ b/includes/admin/class-rop-rest-api.php
@@ -1098,14 +1098,14 @@ class Rop_Rest_Api {
 			$db->migrate_post_formats( $active_accounts );
 		} else {
 			$this->response->set_code( '500' )
-						   ->set_data( array() );
+						   ->set_data( array( 'success' => false ) );
 
 			return $this->response->to_array();
 		}
 
 		$this->response->set_code( '200' )
 					   ->set_message( 'OK' )
-					   ->set_data( array() );
+					   ->set_data( array( 'success' => true ) );
 
 		$rop_facebook_via_rs_app_option = 'rop_facebook_via_rs_app';
 		if ( ! get_option( $rop_facebook_via_rs_app_option ) ) {
@@ -1155,14 +1155,14 @@ class Rop_Rest_Api {
 			$db->migrate_post_formats( $active_accounts );
 		} else {
 			$this->response->set_code( '500' )
-						   ->set_data( array() );
+						   ->set_data( array( 'success' => false ) );
 
 			return $this->response->to_array();
 		}
 
 		$this->response->set_code( '200' )
 					   ->set_message( 'OK' )
-					   ->set_data( array() );
+					   ->set_data( array( 'success' => true ) );
 
 		$rop_twitter_via_rs_app_option = 'rop_twitter_via_rs_app';
 		if ( ! get_option( $rop_twitter_via_rs_app_option ) ) {
@@ -1208,14 +1208,14 @@ class Rop_Rest_Api {
 			$db->migrate_post_formats( $active_accounts );
 		} else {
 			$this->response->set_code( '500' )
-						   ->set_data( array() );
+						   ->set_data( array( 'success' => false ) );
 
 			return $this->response->to_array();
 		}
 
 		$this->response->set_code( '200' )
 					   ->set_message( 'OK' )
-					   ->set_data( array() );
+					   ->set_data( array( 'success' => true ) );
 
 		$rop_linkedin_via_rs_app_option = 'rop_linkedin_via_rs_app';
 		if ( ! get_option( $rop_linkedin_via_rs_app_option ) ) {
@@ -1260,14 +1260,14 @@ class Rop_Rest_Api {
 			$db->migrate_post_formats( $active_accounts );
 		} else {
 			$this->response->set_code( '500' )
-						   ->set_data( array() );
+						   ->set_data( array( 'success' => false ) );
 
 			return $this->response->to_array();
 		}
 
 		$this->response->set_code( '200' )
 					   ->set_message( 'OK' )
-					   ->set_data( array() );
+					   ->set_data( array( 'success' => true ) );
 
 		$rop_tumblr_via_rs_app_option = 'rop_tumblr_via_rs_app';
 		if ( ! get_option( $rop_tumblr_via_rs_app_option ) ) {
@@ -1312,14 +1312,14 @@ class Rop_Rest_Api {
 			$db->migrate_post_formats( $active_accounts );
 		} else {
 			$this->response->set_code( '500' )
-						   ->set_data( array() );
+						   ->set_data( array( 'success' => false ) );
 
 			return $this->response->to_array();
 		}
 
 		$this->response->set_code( '200' )
 					   ->set_message( 'OK' )
-					   ->set_data( array() );
+					   ->set_data( array( 'success' => true ) );
 
 		return $this->response->to_array();
 	}
@@ -1356,14 +1356,14 @@ class Rop_Rest_Api {
 			$db->migrate_post_formats( $active_accounts );
 		} else {
 			$this->response->set_code( '500' )
-						   ->set_data( array() );
+						   ->set_data( array( 'success' => false ) );
 
 			return $this->response->to_array();
 		}
 
 		$this->response->set_code( '200' )
 					   ->set_message( 'OK' )
-					   ->set_data( array() );
+					   ->set_data( array( 'success' => true ) );
 
 		return $this->response->to_array();
 	}

--- a/vue/src/models/rop_store.js
+++ b/vue/src/models/rop_store.js
@@ -339,16 +339,18 @@ export default new Vuex.Store({
                         if (data.updateState !== false) {
                             commit('updateState', {stateData, requestName})
                         }
-                    }, function () {
+                    }, function (error) {
                         commit('setAjaxState', false);
                         commit('apiNotAvailable', true);
 
                         Vue.$log.error('Error when trying to do request: ', data.req);
+                        reject(error);
                     }).catch(error => {
                         commit('setAjaxState', false);
                         commit('apiNotAvailable', true);
                         commit('preloading_change', 1);
                         Vue.$log.error('Error when getting response for: ', data.req, error);
+                        reject(error);
                     })
                 })
             }

--- a/vue/src/rop_main.js
+++ b/vue/src/rop_main.js
@@ -7,6 +7,16 @@ import Vue from 'vue'
 import store from './models/rop_store.js'
 import MainPagePanel from './vue-elements/main-page-panel.vue'
 
+/**
+ * Consume a rejected start-up request, so it does not surface as an unhandled rejection.
+ *
+ * @param {string} req Name of the request which failed.
+ * @returns {Function} Rejection handler.
+ */
+const logStartupFailure = ( req ) => ( error ) => {
+	Vue.$log.error( 'Could not load ' + req + ' when starting the dashboard.', error )
+}
+
 window.addEventListener( 'load', function () {
 	var RopApp = new Vue( {
 		el: '#rop_core',
@@ -16,9 +26,9 @@ window.addEventListener( 'load', function () {
 		},
 		created() {
 			store.dispatch( 'fetchAJAX', {req: 'manage_cron', data: {action: 'status'}} )
-			store.dispatch( 'fetchAJAXPromise', {req: 'get_available_services'} )
-			store.dispatch( 'fetchAJAXPromise', {req: 'get_authenticated_services'} )
-			store.dispatch( 'fetchAJAXPromise', {req: 'get_active_accounts'} )
+			store.dispatch( 'fetchAJAXPromise', {req: 'get_available_services'} ).catch( logStartupFailure( 'get_available_services' ) )
+			store.dispatch( 'fetchAJAXPromise', {req: 'get_authenticated_services'} ).catch( logStartupFailure( 'get_authenticated_services' ) )
+			store.dispatch( 'fetchAJAXPromise', {req: 'get_active_accounts'} ).catch( logStartupFailure( 'get_active_accounts' ) )
 		},
 	} );
 } );

--- a/vue/src/vue-elements/accounts-tab-panel.vue
+++ b/vue/src/vue-elements/accounts-tab-panel.vue
@@ -225,11 +225,11 @@
                         this.is_loading = false;
                     }, error => {
                         this.is_loading = false;
-                        Vue.$log.error('Could not refresh the available services after resetting the accounts.', error)
+                        this.$log.error('Could not refresh the available services after resetting the accounts.', error)
                     })
                 }, error => {
                     this.is_loading = false;
-                    Vue.$log.error('Got nothing from server. Prompt user to check internet connection and try again', error)
+                    this.$log.error('Got nothing from server. Prompt user to check internet connection and try again', error)
                 })
             },
             filteredAccounts: function(accounts) {

--- a/vue/src/vue-elements/accounts-tab-panel.vue
+++ b/vue/src/vue-elements/accounts-tab-panel.vue
@@ -223,6 +223,9 @@
                         req: 'get_available_services'
                     }).then(response => {
                         this.is_loading = false;
+                    }, error => {
+                        this.is_loading = false;
+                        Vue.$log.error('Could not refresh the available services after resetting the accounts.', error)
                     })
                 }, error => {
                     this.is_loading = false;

--- a/vue/src/vue-elements/post-format.vue
+++ b/vue/src/vue-elements/post-format.vue
@@ -1056,7 +1056,9 @@
                     this.post_format.taxonomy_filter = [];
                 }
                 if(lang !== ''){
-                    this.$store.dispatch('fetchAJAXPromise', {req: 'get_taxonomies', data: {post_types: this.postTypes, language_code: lang}});
+                    this.$store.dispatch('fetchAJAXPromise', {req: 'get_taxonomies', data: {post_types: this.postTypes, language_code: lang}}).catch(error => {
+                      Vue.$log.error('Could not fetch the taxonomies for the selected language.', error)
+                    });
                 }
                 this.$store.state.dom_updated = true;
             },

--- a/vue/src/vue-elements/post-format.vue
+++ b/vue/src/vue-elements/post-format.vue
@@ -1027,7 +1027,7 @@
                 }).then(response => {
                     this.post_format.shortner_credentials = response
                 }, error => {
-                    Vue.$log.error('Got nothing from server. Prompt user to check internet connection and try again', error)
+                    this.$log.error('Got nothing from server. Prompt user to check internet connection and try again', error)
                 })
             }
         },
@@ -1057,7 +1057,7 @@
                 }
                 if(lang !== ''){
                     this.$store.dispatch('fetchAJAXPromise', {req: 'get_taxonomies', data: {post_types: this.postTypes, language_code: lang}}).catch(error => {
-                      Vue.$log.error('Could not fetch the taxonomies for the selected language.', error)
+                      this.$log.error('Could not fetch the taxonomies for the selected language.', error)
                     });
                 }
                 this.$store.state.dom_updated = true;

--- a/vue/src/vue-elements/sign-in-btn.vue
+++ b/vue/src/vue-elements/sign-in-btn.vue
@@ -883,12 +883,6 @@ export default {
         storing = this.addAccountGmb( accountData );
       } else if ('Vk' === serviceName) {
         storing = this.addAccountVk( accountData );
-      } else if ('Webhook' === serviceName) {
-        storing = this.addAccountWebhook( accountData );
-      } else if ('Telegram' === serviceName) {
-        storing = this.addAccountTelegram( accountData );
-      } else if ('Bluesky' === serviceName) {
-        storing = this.addAccountBluesky( accountData );
       } else {
         return;
       }

--- a/vue/src/vue-elements/sign-in-btn.vue
+++ b/vue/src/vue-elements/sign-in-btn.vue
@@ -731,106 +731,81 @@ export default {
       this.$store.commit( 'setEditPopupShowPermission', false );
     },
     /**
-     * Add Facebook account.
+     * Store an account received from an authorization popup.
      *
-     * @param data Data.
+     * The returned promise must be awaited before reloading the dashboard, otherwise the
+     * reload can abort the request and the account is never stored.
+     *
+     * @param req  Name of the REST request.
+     * @param data Account data.
+     * @returns {Promise} Resolved once the account has been stored, rejected otherwise.
      */
-    addAccountFB(data) {
-      this.$store.dispatch('fetchAJAXPromise', {
-        req: 'add_account_fb',
+    persistAccount( req, data ) {
+      return this.$store.dispatch('fetchAJAXPromise', {
+        req: req,
         updateState: false,
         data: data
       }).then(response => {
-        window.removeEventListener("message", event => this.getChildWindowMessage(event));
-      }, error => {
-        this.is_loading = false;
-        Vue.$log.error('Got nothing from server. Prompt user to check internet connection and try again', error)
+        if ( response && false === response.success ) {
+          throw new Error( req + ': the account was not stored.' );
+        }
+
+        return response;
       });
+    },
+    /**
+     * Add Facebook account.
+     *
+     * @param data Data.
+     * @returns {Promise} Resolved once the account has been stored, rejected otherwise.
+     */
+    addAccountFB(data) {
+      return this.persistAccount( 'add_account_fb', data );
     },
     /**
      * Add Twitter account.
      *
      * @param data Data.
+     * @returns {Promise} Resolved once the account has been stored, rejected otherwise.
      */
     addAccountTW(data) {
-      this.$store.dispatch('fetchAJAXPromise', {
-        req: 'add_account_tw',
-        updateState: false,
-        data: data
-      }).then(() => {
-        window.removeEventListener("message", this.getChildWindowMessage );
-      }, error => {
-        this.is_loading = false;
-        Vue.$log.error('Got nothing from server. Prompt user to check internet connection and try again', error)
-      });
+      return this.persistAccount( 'add_account_tw', data );
     },
     /**
      * Add LinkedIn account.
      *
      * @param data Data.
+     * @returns {Promise} Resolved once the account has been stored, rejected otherwise.
      */
     addAccountLI(data) {
-      this.$store.dispatch('fetchAJAXPromise', {
-        req: 'add_account_li',
-        updateState: false,
-        data: data
-      }).then(() => {
-        window.removeEventListener("message", this.getChildWindowMessage );
-      }, error => {
-        this.is_loading = false;
-        Vue.$log.error('Got nothing from server. Prompt user to check internet connection and try again', error)
-      });
+      return this.persistAccount( 'add_account_li', data );
     },
     /**
      * Add Tumblr account.
      *
      * @param data Data.
+     * @returns {Promise} Resolved once the account has been stored, rejected otherwise.
      */
     addAccountTumblr(data) {
-      this.$store.dispatch('fetchAJAXPromise', {
-        req: 'add_account_tumblr',
-        updateState: false,
-        data: data
-      }).then(() => {
-        window.removeEventListener("message", this.getChildWindowMessage );
-      }, error => {
-        this.is_loading = false;
-        Vue.$log.error('Got nothing from server. Prompt user to check internet connection and try again', error)
-      });
+      return this.persistAccount( 'add_account_tumblr', data );
     },
     /**
      * Add Google My Business account.
      *
      * @param data Data.
+     * @returns {Promise} Resolved once the account has been stored, rejected otherwise.
      */
     addAccountGmb(data) {
-      this.$store.dispatch('fetchAJAXPromise', {
-        req: 'add_account_gmb',
-        updateState: false,
-        data: data
-      }).then(() => {
-        window.removeEventListener("message", this.getChildWindowMessage );
-      }, error => {
-        this.is_loading = false;
-        Vue.$log.error('Got nothing from server. Prompt user to check internet connection and try again', error)
-      });
+      return this.persistAccount( 'add_account_gmb', data );
     },
     /**
      * Add VK account.
      *
      * @param data Data.
+     * @returns {Promise} Resolved once the account has been stored, rejected otherwise.
      */
     addAccountVk(data) {
-      this.$store.dispatch('fetchAJAXPromise', {
-        req: 'add_account_vk',
-        updateState: false,
-        data: data
-      }).then(() => {
-        window.removeEventListener("message", this.getChildWindowMessage );
-      }, error => {
-        this.is_loading = false;
-        Vue.$log.error('Got nothing from server. Prompt user to check internet connection and try again', error)
-      });
+      return this.persistAccount( 'add_account_vk', data );
     },
     /**
      * Add Bluesky account.
@@ -893,27 +868,80 @@ export default {
       }
 
       const accountData = JSON.parse(event.data);
+      const serviceName = this.modal.serviceName;
+      let storing;
 
-      if ('Twitter' === this.modal.serviceName) {
-        this.addAccountTW( accountData );
-      } else if ('Facebook' === this.modal.serviceName || 'Instagram' === this.modal.serviceName) {
-        this.addAccountFB( accountData );
-      } else if ('LinkedIn' === this.modal.serviceName) {
-        this.addAccountLI( accountData );
-      } else if ('Tumblr' === this.modal.serviceName) {
-        this.addAccountTumblr( accountData );
-      } else if ('Gmb' === this.modal.serviceName) {
-        this.addAccountGmb( accountData );
-      } else if ('Vk' === this.modal.serviceName) {
-        this.addAccountVk( accountData );
-      } else if ('Webhook' === this.modal.serviceName) {
-        this.addAccountWebhook( accountData );
-      } else if ('Telegram' === this.modal.serviceName) {
-        this.addAccountTelegram( accountData );
-      } else if ('Bluesky' === this.modal.serviceName) {
-        this.addAccountBluesky( accountData );
+      if ('Twitter' === serviceName) {
+        storing = this.addAccountTW( accountData );
+      } else if ('Facebook' === serviceName || 'Instagram' === serviceName) {
+        storing = this.addAccountFB( accountData );
+      } else if ('LinkedIn' === serviceName) {
+        storing = this.addAccountLI( accountData );
+      } else if ('Tumblr' === serviceName) {
+        storing = this.addAccountTumblr( accountData );
+      } else if ('Gmb' === serviceName) {
+        storing = this.addAccountGmb( accountData );
+      } else if ('Vk' === serviceName) {
+        storing = this.addAccountVk( accountData );
+      } else if ('Webhook' === serviceName) {
+        storing = this.addAccountWebhook( accountData );
+      } else if ('Telegram' === serviceName) {
+        storing = this.addAccountTelegram( accountData );
+      } else if ('Bluesky' === serviceName) {
+        storing = this.addAccountBluesky( accountData );
+      } else {
+        return;
       }
 
+      window.removeEventListener("message", this.getChildWindowMessage );
+
+      // The account has to be stored before the dashboard reloads: reloading while the
+      // request is in flight lets the browser cancel it and the account is lost.
+      try {
+        await storing;
+      } catch ( error ) {
+        this.$log.error( 'Could not store the ' + serviceName + ' account.', error );
+        this.showServiceError( serviceName );
+        this.closeAuthPopup();
+        this.$store.state.auth_in_progress = false;
+        return;
+      }
+
+      await this.trackAddedAccount();
+      this.closeAuthPopup();
+
+      window.location.reload();
+    },
+    /**
+     * Close the authorization popup, if it is still around.
+     */
+    closeAuthPopup() {
+      try {
+        this.authPopupWindow.close();
+      } catch (e) {
+        // nothing to do
+      }
+    },
+    /**
+     * Show an error toast for a service which could not be connected.
+     *
+     * @param serviceName Service name.
+     */
+    showServiceError( serviceName ) {
+      this.$store.commit( 'updateState', {
+        stateData: {
+          type: 'error',
+          show: true,
+          title: this.displayName( serviceName ),
+          message: wp.i18n.sprintf( this.labels.service_error, this.displayName( serviceName ) )
+        },
+        requestName: 'update_toast'
+      } );
+    },
+    /**
+     * Send the add-account tracking event.
+     */
+    trackAddedAccount: async function () {
       try {
         window?.tiTrk?.with('tweet')?.add({
           feature: 'add-account',
@@ -924,8 +952,6 @@ export default {
       } catch (e) {
         console.warn( e );
       }
-
-      window.location.reload();
     },
     addWebhookHeader() {
       if ( ! this.currentWebhookHeader ) {


### PR DESCRIPTION
### Summary
Improved the error handling for social account connections and updated the `fetchAJAXPromise` action to properly handle promise rejections by logging errors and allowing upstream callers to handle errors gracefully.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/tweet-old-post/issues/1099

### Why no test

The authorization popup is served by `app.revive.social`, and `getChildWindowMessage` only accepts messages from that origin. Covering this in a test would require stubbing the external authentication app as a separate origin in the test harness. The existing E2E mock only intercepts server-side HTTP requests via `pre_http_request` and cannot interact with a cross-origin browser popup.

Additionally, the regression we're guarding against is a "reload fired too early" scenario, which would require asserting that a page navigation **does not** occur within a given time window. That type of negative timing assertion tends to be inherently flaky, making it a poor fit for a reliable automated test.
