### PR TITLE
ci: fix malformed dependabot.yml (duplicate ignore key)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,8 @@ updates:
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"
-    ignore:
-    - dependency-name: "facebook/graph-sdk*" 
     target-branch: "development"
     ignore:
-    - dependency-name: "facebook/graph-sdk*" 
+      - dependency-name: "facebook/graph-sdk*"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The composer block in `.github/dependabot.yml` had the `ignore:` key twice (an invalid duplicate mapping key), which caused Dependabot to reject the config and stop opening update PRs for this repo (no Dependabot PRs since Jan 2025). This consolidates to a single `ignore` block so Dependabot resumes and picks up the pending themeisle-sdk update.